### PR TITLE
fix: exclude archived repositories

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function getPullRequests() {
 
   await octokit
     .paginate(octokit.rest.search.issuesAndPullRequests, {
-      q: `${RENOVATE_PR_QUALIFIERS} "${AUTOMERGE_MESSAGE}" in:body review:required state:open type:pr`,
+      q: `${RENOVATE_PR_QUALIFIERS} "${AUTOMERGE_MESSAGE}" archived:false in:body review:required state:open type:pr`,
     })
     .then((items) => {
       prs = prs.concat(items);


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

As in title

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

The bot could try to approve PRs on archived/read-only repositories 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/maxbrunet/renovate-approve-job/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
